### PR TITLE
feat: add ask-password support

### DIFF
--- a/asahi/asahi.script
+++ b/asahi/asahi.script
@@ -26,7 +26,64 @@ bar;
 fill;
 slider;
 message;
+password;
 
+
+fun display_password(prompt, bullets) {
+    /* Switch to password mode */
+    if (!password.active) {
+        password.active = 1;
+
+        /* Hide normal assets */
+        bar.sprite.SetOpacity(0);
+        slider.sprite.SetOpacity(0);
+        fill.sprite.SetOpacity(0);
+        message.sprite.SetOpacity(0);
+
+        /* Show password assets */
+        password.prompt_sprite.SetOpacity(1);
+        password.bullets_sprite.SetOpacity(1);
+    }
+
+    /* Update prompt text */
+    password.prompt_text = Image.Text(prompt, 1, 1, 1, "center");
+    password.prompt_sprite.SetImage(password.prompt_text);
+    password.prompt_sprite.SetX((width / 2) - (password.prompt_text.GetWidth() / 2));
+    password.prompt_sprite.SetY(bar.y * 1.02); // place password prompt where messages will appear
+
+    /* Build bullet string */
+    dots = "";
+    i = 0;
+    while (i < bullets) {
+        dots = dots + "•";
+        i = i + 1;
+    }
+
+    /* Update bullets text */
+    password.bullets_text = Image.Text(dots, 1, 1, 1, "center");
+    password.bullets_sprite.SetImage(password.bullets_text);
+    password.bullets_sprite.SetX((width / 2) - (password.bullets_text.GetWidth() / 2));
+    password.bullets_sprite.SetY(bar.y); // place bullet string where progressbar will appear
+}
+Plymouth.SetDisplayPasswordFunction(display_password);
+
+fun display_normal() {
+    /* Switch to normal mode */
+    if (password.active) {
+        password.active = 0;
+
+        /* Hide password assets */
+        password.prompt_sprite.SetOpacity(0);
+        password.bullets_sprite.SetOpacity(0);
+
+        /* Restore normal assets */
+        bar.sprite.SetOpacity(1);
+        slider.sprite.SetOpacity(1);
+        fill.sprite.SetOpacity(1);
+        message.sprite.SetOpacity(1);
+    }
+}
+Plymouth.SetDisplayNormalFunction(display_normal);
 
 fun show_message(text) {
     message.text = Image.Text(text, 1, 1, 1, "center");
@@ -57,10 +114,14 @@ Plymouth.SetBootProgressFunction(set_progress);
 
 
 fun init() {
+    /* Initialize password dialog state */
+    password.active = 0;
+
     /* Set background colour to black */
     Window.SetBackgroundTopColor(0.0, 0.0, 0.0);
     Window.SetBackgroundBottomColour(0.0, 0.0, 0.0);
 
+    /* Initialize logo */
     logo.image = Image("asahi.png");
     logo.image = logo.image.Scale(logo.image.GetWidth() * 0.5, logo.image.GetHeight() * 0.5);
     logo.sprite = Sprite(logo.image);
@@ -69,6 +130,7 @@ fun init() {
     logo.sprite.SetPosition(logo.x, logo.y, 1000);
     logo.sprite.SetOpacity(1);
 
+    /* Initialize progress bar */
     /* We create a rectangular sprite the same colour as the background,
      * place it over the bar fill but *under* the bar outline, and then
      * shift it to the right of the screen so that the bar appears to be
@@ -88,6 +150,17 @@ fun init() {
     slider.sprite = Sprite(slider.image);
     slider.x = bar.x; /* We need to move this sprite alone */
     slider.sprite.SetPosition(bar.x, bar.y, 1001);
+
+    /* Initialize password dialog sprites */
+    password.prompt_text = Image.Text("", 1, 1, 1, "center");
+    password.prompt_sprite = Sprite(password.prompt_text);
+    password.prompt_sprite.SetZ(1005);
+    password.prompt_sprite.SetOpacity(0);
+
+    password.bullets_text = Image.Text("", 1, 1, 1, "center");
+    password.bullets_sprite = Sprite(password.bullets_text);
+    password.bullets_sprite.SetZ(1005);
+    password.bullets_sprite.SetOpacity(0);
 
     if (Plymouth.GetMode() != "boot") {
         bar.sprite.SetOpacity(0);


### PR DESCRIPTION
Hello :wave: 

I’ve added support for ask-password to enable a nice-looking unlock prompt for encrypted devices during the Plymouth display as I run on a LUKS volume myself !

I noticed the legacy approach using bullet images, but I felt that using a bullet character from a font would be simpler and more reliable.

Here’s a short video showing what the ask-password prompt looks like in action:

https://github.com/user-attachments/assets/d0374a7d-ff09-4821-9938-f9a90880eb17

I tested it on Asahi ALARM (M1), Arch (x86_64) and Debian (inside a VM), it works pretty well !

Let me know if anything is wrong or can be enhanced

bye